### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Sub7espeto/juice-shop-ADA-1466/security/code-scanning/53](https://github.com/Sub7espeto/juice-shop-ADA-1466/security/code-scanning/53)

To securely implement order tracking and eliminate code injection, we should **avoid** using MongoDB’s `$where` query with user-supplied data. Instead, use a regular field comparison query. Rather than passing a JavaScript predicate, search with `{ orderId: id }`, which is safe and does not evaluate any code. 

#### Steps:
- Replace the use of `$where` with a direct match on the `orderId` field: `.find({ orderId: id })`.
- No additional runtime imports are required—this method is standard for MongoDB queries.
- Ensure this change is made where the user input (`id`) is involved: line 18 of `routes/trackOrder.ts`.
- No need to change the wrapping logic or result handling—the only required change is the way the database query is constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
