### PR TITLE
Potential fix for code scanning alert no. 76: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,9 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      criteria = ''
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Sub7espeto/juice-shop-ADA-1466/security/code-scanning/76](https://github.com/Sub7espeto/juice-shop-ADA-1466/security/code-scanning/76)

The correct fix is to ensure that the query parameter (`req.query.q`) is always treated as a string; if it is received as an array or any other type, it should be rejected or sanitized to an acceptable, unambiguous value. 

**Specifically:**  
- At the beginning of the handler, after fetching the raw user input, check if `criteria` is a string.  
- If it is not a string (e.g., it's an array or `undefined`), set it to an empty string or return an error response.  
- This must be done prior to any calls to `.length`, `.substring`, or string concatenation, and preferably before any use of the value at all.

**Lines/regions to change:**  
- Just after `let criteria: any = ...` is assigned on line 21.
- Insert a type check. If not a string, force to empty string (or, depending on business logic, reject the request with an error).

**No additional methods, imports, or definitions are required, as type checking and assignment are native JS.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
